### PR TITLE
Added ability for SUCM and TCC to reserve a booth

### DIFF
--- a/cookie_website/cookie_booths/models.py
+++ b/cookie_website/cookie_booths/models.py
@@ -383,7 +383,9 @@ class BoothBlock(models.Model):
 
     class Meta:
         permissions = (('cancel_block', "Cancel a booth"),
-                       ('reserve_block', "Reserve a booth")
+                       ('reserve_block', "Reserve a booth"),
+                       ('cancel_block_admin', "Administrator cancel any booth"),
+                       ('reserve_block_admin', "Administrator reserve any booth"),
                        )
 
     def cancel_block(self, troop_id):

--- a/cookie_website/cookie_booths/templates/cookie_booths/booth_blocks.html
+++ b/cookie_website/cookie_booths/templates/cookie_booths/booth_blocks.html
@@ -8,44 +8,102 @@
 
 
 {% block content %}
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css">
 
-<table id="booth_blocks" class="table table-striped table-bordered">
-	<thead>
-    	<tr>
-			<th>Location</th>
-			<th>Address</th>
-			<th>Date</th>
-			<th>Start Time</th>
-			<th>End Time</th>
-            <th>Manage</th>
-		</tr>
-	</thead>
-	<tbody>
-		{% for block in booth_blocks %}
-			<tr>
-				<td>{{ block.booth_day.booth.booth_location }}</td>
-				<td>{{ block.booth_day.booth.booth_address }}</td>
-				<td>{{ block.booth_day.booth_day_date }}</td>
-				<td>{{ block.booth_block_start_time|date:"h:i A" }}</td>
-				<td>{{ block.booth_block_end_time|date:"h:i A" }}</td>
-				<td>
-                    {% if perms.cookie_booths.cancel_block or perms.cookie_booths.reserve_block %}
-                        <!-- TODO: need to dynamically set this value based on whether that particular block is reserved by this user -->
-                    {% endif %}
-                </td>
-			</tr>
-		{% endfor %}
-	</tbody>
-</table>
+    {% if perms.cookie_booths.reserve_block_admin %}
+        <p><div>
+            <select name="TroopNumbers" id="TroopNumbers">
+                <option value="none" selected disabled hidden>Select a Troop</option>
+                {% for troop in available_troops %}
+                    <option value="{{ troop.troop_number }}">{{ troop }}</option>
+                {% endfor %}
+            </select>
+        </div></p>
+    {% endif %}
 
-<script src="https://code.jquery.com/jquery-3.5.1.js"></script>
-<script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
-<script type="text/javascript">
+    <table id="booth_blocks" class="table table-striped table-bordered">
+        <thead>
+            <tr>
+                <th>Location</th>
+                <th>Address</th>
+                <th>Date</th>
+                <th>Start Time</th>
+                <th>End Time</th>
+                <th>Manage</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for block in booth_blocks %}
+                <tr>
+                    <td>{{ block.booth_day.booth.booth_location }}</td>
+                    <td>{{ block.booth_day.booth.booth_address }}</td>
+                    <td>{{ block.booth_day.booth_day_date }}</td>
+                    <td>{{ block.booth_block_start_time|date:"h:i A" }}</td>
+                    <td>{{ block.booth_block_end_time|date:"h:i A" }}</td>
+                    <td>
+                        {% if block.booth_block_reserved is False %}
+                            {% if perms.cookie_booths.reserve_block or perms.cookie_booths.reserve_block_admin %}
+                                <input type="button" id="ReserveBooth" value="Reserve Booth"
+                                       onclick="ReserveBooth({{ block.id }})">
+                            {% endif %}
+                        {% else %}
+                            {% if perms.cookie_booths.cancel_block_admin %}
+                                Reserved by {{ block.booth_block_current_troop_owner }}
+                                <p></p>
+                                <input type="button" id="CancelBooth" value="Cancel Booth">
+                            {% elif booth_owned_by_current_user is True %}
+                                <input type="button" id="CancelBooth" value="Cancel Booth">
+                            {% else %}
+                                Reserved by {{ block.booth_block_current_troop_owner }}
+                            {% endif %}
+                        {% endif %}
+
+
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+    <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
+
+    <script type="text/javascript">
     $(document).ready(function() {
         $('#booth_blocks').DataTable( {
     	    "paging":   false,
         } );
     } );
-</script>
+    </script>
+
+    <script>
+        function ReserveBooth(booth_id) {
+            $.ajax({
+                url: booth_id,
+                type: 'POST',
+                data: {
+                        csrfmiddlewaretoken: '{{ csrf_token }}',
+                        troop_number: $('#TroopNumbers').val()
+                },
+                success: function(jsonData) {
+                    let from_response = JSON.parse(jsonData);
+                    let is_success = from_response.is_success;
+                    let message = from_response.message;
+                    if (is_success===true){
+                        if(confirm(message)) {
+                            window.location.reload()
+                        }
+                    }
+                    else {
+                        alert(message)
+                    }
+
+
+                }
+            });
+
+        }
+    </script>
+
+
 {% endblock content %}

--- a/cookie_website/users/views.py
+++ b/cookie_website/users/views.py
@@ -53,6 +53,7 @@ def edit_troop(request, troop_number):
     context = {'troop': troop, 'form': form}
     return render(request, 'troops/edit_troop.html', context)
 
+
 class TroopDelete(PermissionRequiredMixin, LoginRequiredMixin, DeleteView):
     """Delete an existing booth location"""
     permission_required = 'users.troop_deletion'


### PR DESCRIPTION
Resolves #22

Changes:
+ Updated cookie_booths/views.py to include reserve_booth functionality
+ Minor whitespace change to users/views.py
+ Added permissions to BoothBlock for SUCMs
+ Completely updated booth_blocks.html to include:
  + Added dropdown menu to select troop for SUCM. Only viewable by SUCM
  + Added information to the manage column, including buttons for reserve, cancel and information about who owns the booth
  + Created ajax function to post information without needing to go to a new page. On success, tell the user and refresh the page to show updates; On failure alert the user of what failed.

Testing:
+ Manual Testing with admin, SUCM and TCC accounts.