### PR TITLE
Added ability for SUCM and TCC to cancel a booth

### DIFF
--- a/cookie_website/cookie_booths/models.py
+++ b/cookie_website/cookie_booths/models.py
@@ -388,11 +388,26 @@ class BoothBlock(models.Model):
                        ('reserve_block_admin', "Administrator reserve any booth"),
                        )
 
-    def cancel_block(self, troop_id):
-        # TODO: Need to Enforce permissions to allow canceling only if the calling user either
-        # 1. Is associated with the troop currently reserving this block, in which case they can do this
-        # 2. Has a superuser permission and can cancel any block here
-        return
+    def cancel_block(self):
+        # If this block is not enabled, no reservation can be made
+        if not self.booth_block_enabled:
+            return False
+
+        # If this block is not reserved, we cannot cancel the block
+        if self.booth_block_reserved:
+            pass
+        else:
+            return False
+
+        # At this point we can cancel the reservation
+        self.booth_block_reserved = False
+        self.booth_block_current_troop_owner = 0
+
+        # TODO: Send email confirmation
+
+        self.save()
+
+        return True
 
     def reserve_block(self, troop_id):
         # If this block is not enabled, no reservation can be made
@@ -407,7 +422,7 @@ class BoothBlock(models.Model):
         self.booth_block_reserved = True
         self.booth_block_current_troop_owner = troop_id
 
-        # TODO: Send email confirmation?
+        # TODO: Send email confirmation
 
         self.save()
         return True

--- a/cookie_website/cookie_booths/templates/cookie_booths/base.html
+++ b/cookie_website/cookie_booths/templates/cookie_booths/base.html
@@ -39,7 +39,7 @@
             {%  endif %}
 
             <a class="dropdown-item" href="{% url 'cookie_booths:booth_blocks' %}">Make Booth Reservations</a>
-            <a class="dropdown-item" href="{% url 'cookie_booths:booth_reservations' %}">Manage Booth Reservations</a>
+            <a class="dropdown-item" href="{% url 'cookie_booths:booth_reservations' %}">Manage Your Booth Reservations</a>
           </div>
         </li>
         <li class="nav-item">

--- a/cookie_website/cookie_booths/templates/cookie_booths/booth_blocks.html
+++ b/cookie_website/cookie_booths/templates/cookie_booths/booth_blocks.html
@@ -3,7 +3,7 @@
 
 
 {% block page_header %}
-  <h2>Booth Reservations</h2>
+  <h2>{{ page_title }}</h2>
 {% endblock page_header %}
 
 
@@ -35,26 +35,29 @@
         <tbody>
             {% for block in booth_blocks %}
                 <tr>
-                    <td>{{ block.booth_day.booth.booth_location }}</td>
-                    <td>{{ block.booth_day.booth.booth_address }}</td>
-                    <td>{{ block.booth_day.booth_day_date }}</td>
-                    <td>{{ block.booth_block_start_time|date:"h:i A" }}</td>
-                    <td>{{ block.booth_block_end_time|date:"h:i A" }}</td>
+                    <td>{{ block.booth_block_information.booth_day.booth.booth_location }}</td>
+                    <td>{{ block.booth_block_information.booth_day.booth.booth_address }}</td>
+                    <td>{{ block.booth_block_information.booth_day.booth_day_date }}</td>
+                    <td>{{ block.booth_block_information.booth_block_start_time|date:"h:i A" }}</td>
+                    <td>{{ block.booth_block_information.booth_block_end_time|date:"h:i A" }}</td>
                     <td>
-                        {% if block.booth_block_reserved is False %}
+                        {% if block.booth_block_information.booth_block_reserved is False %}
                             {% if perms.cookie_booths.reserve_block or perms.cookie_booths.reserve_block_admin %}
                                 <input type="button" id="ReserveBooth" value="Reserve Booth"
-                                       onclick="ReserveBooth({{ block.id }})">
+                                       onclick="ReserveBooth({{ block.booth_block_information.id }})">
                             {% endif %}
+
                         {% else %}
                             {% if perms.cookie_booths.cancel_block_admin %}
-                                Reserved by {{ block.booth_block_current_troop_owner }}
+                                Reserved by {{ block.booth_block_information.booth_block_current_troop_owner }}
                                 <p></p>
-                                <input type="button" id="CancelBooth" value="Cancel Booth">
-                            {% elif booth_owned_by_current_user is True %}
-                                <input type="button" id="CancelBooth" value="Cancel Booth">
+                                <input type="button" id="CancelBooth" value="Cancel Booth"
+                                        onclick="CancelBooth({{ block.booth_block_information.id }})">
+                            {% elif  block.booth_owned_by_current_user is True %}
+                                <input type="button" id="CancelBooth" value="Cancel Booth"
+                                        onclick="CancelBooth({{ block.booth_block_information.id }})">
                             {% else %}
-                                Reserved by {{ block.booth_block_current_troop_owner }}
+                                Reserved by {{ block.booth_block_information.booth_block_current_troop_owner }}
                             {% endif %}
                         {% endif %}
 
@@ -79,7 +82,7 @@
     <script>
         function ReserveBooth(booth_id) {
             $.ajax({
-                url: booth_id,
+                url: location.origin + "/booths/blocks/reservations/" + booth_id,
                 type: 'POST',
                 data: {
                         csrfmiddlewaretoken: '{{ csrf_token }}',
@@ -93,6 +96,10 @@
                         if(confirm(message)) {
                             window.location.reload()
                         }
+                        // Make sure cancelling also prompts a refresh
+                        else {
+                            window.location.reload()
+                        }
                     }
                     else {
                         alert(message)
@@ -102,6 +109,40 @@
                 }
             });
 
+        }
+
+        function CancelBooth(booth_id) {
+            if(confirm("Do you want to cancel your reservation for this booth?")) {
+                $.ajax({
+                    url: location.origin + "/booths/blocks/reservations/cancel/" + booth_id,
+                    type: 'POST',
+                    data: {
+                        csrfmiddlewaretoken: '{{ csrf_token }}',
+                        troop_number: $('#TroopNumbers').val()
+                    },
+                    success: function (jsonData) {
+                        let from_response = JSON.parse(jsonData);
+                        let is_success = from_response.is_success;
+                        let message = from_response.message;
+                        if (is_success === true) {
+                            if (confirm(message)) {
+                                window.location.reload()
+                            }
+                            // Make sure cancelling also prompts a refresh
+                            else {
+                                window.location.reload()
+                            }
+                        } else {
+                            alert(message)
+                        }
+
+
+                    }
+                });
+            }
+            else {
+                alert("There has been no change to your reservation")
+                }
         }
     </script>
 

--- a/cookie_website/cookie_booths/urls.py
+++ b/cookie_website/cookie_booths/urls.py
@@ -16,10 +16,12 @@ urlpatterns = [
     path('booths/edit_booth/<int:booth_id>/hours/', views.edit_booth_location_hours, name='edit_booth_hours'),
     # Delete Booth
     path('booths/booth_confirm_delete/<int:pk>/', views.BoothLocationDelete.as_view(), name='delete_booth'),
-    # Booth Blocks Home
+    # Manage Booth Blocks Home
     path('booths/blocks/', views.booth_blocks, name='booth_blocks'),
-    # Booth Reservations
-    path('booths/reservations/', views.booth_reservations, name='booth_reservations'),
-    # Individual Booth Reservation
-    path('booths/reservations/<int:block_id>', views.reserve_block, name='block_reservation'),
+    # Your Booth Reservations
+    path('booths/blocks/reservations/', views.booth_reservations, name='booth_reservations'),
+    # Make Booth Reservation
+    path('booths/blocks/reservations/<int:block_id>', views.reserve_block, name='block_reservation'),
+    # Cancel Booth Reservation
+    path('booths/blocks/reservations/cancel/<int:block_id>', views.cancel_block, name='block_cancellation'),
 ]


### PR DESCRIPTION
Changes:
+ Updated cookie_booths/views.py to include cancel_booth functionality
+ Slight update to base.html to better reflect functionalities, ie Make Booth Reservations and view Your Booth Reservations
+ Updated booth_blocks.html to include javascript function for Cancel functionality, including a confirmation on cancelling your booth.
+ All functionality on booth_blocks.html is using ajax, and will refresh automatically after a reservation or cancellation

Fixed:
+ Issues discovered between Make Booth Reservations and View Your Booth Reservation. Made changes to the context delivered to the pages to make them distinct.
+ Updated javascript url to an absolute url so it would work properly on either Make Booth Reservations or View Your Booth Reservations.

Testing:
+ Manual Testing with admin, SUCM and TCC accounts.

Resolves #28 