### PR TITLE
Added enabling and disabling booths by blocks.

### DIFF
--- a/cookie_website/cookie_booths/templates/cookie_booths/base.html
+++ b/cookie_website/cookie_booths/templates/cookie_booths/base.html
@@ -35,9 +35,12 @@
             <a class="dropdown-item" href="{% url 'cookie_booths:booth_locations' %}">Booth Locations</a>
 
             {% if perms.cookie_booths.booth_loc_creation %}
-              <a class="dropdown-item" href="{% url 'cookie_booths:new_location' %}">New Booth Location</a>
+                <a class="dropdown-item" href="{% url 'cookie_booths:new_location' %}">New Booth Location</a>
             {%  endif %}
-
+            {% if perms.cookie_booth.enable_day %}
+                <a class="dropdown-item" href="{% url 'cookie_booths:enable_location_by_block' %}">Enable Booths by Block</a>
+                <a class="dropdown-item" href="{% url 'cookie_booths:enable_day' %}">Enable Booths by Day</a>
+            {% endif %}
             <a class="dropdown-item" href="{% url 'cookie_booths:booth_blocks' %}">Make Booth Reservations</a>
             <a class="dropdown-item" href="{% url 'cookie_booths:booth_reservations' %}">Manage Your Booth Reservations</a>
           </div>

--- a/cookie_website/cookie_booths/templates/cookie_booths/booth_blocks.html
+++ b/cookie_website/cookie_booths/templates/cookie_booths/booth_blocks.html
@@ -3,14 +3,14 @@
 
 
 {% block page_header %}
-  <h2>{{ page_title }}</h2>
+    <h2>{{ page_title }}</h2>
 {% endblock page_header %}
 
 
 {% block content %}
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css">
 
-    {% if perms.cookie_booths.reserve_block_admin %}
+    {% if perms.cookie_booths.reserve_block_admin and reserve_or_enable_booths == "reserve" %}
         <p><div>
             <select name="TroopNumbers" id="TroopNumbers">
                 <option value="none" selected disabled hidden>Select a Troop</option>
@@ -41,29 +41,37 @@
                     <td>{{ block.booth_block_information.booth_block_start_time|date:"h:i A" }}</td>
                     <td>{{ block.booth_block_information.booth_block_end_time|date:"h:i A" }}</td>
                     <td>
+                        {% if reserve_or_enable_booths == "reserve" %}
+                            {% if block.booth_block_information.booth_block_reserved is False %}
+                                {% if perms.cookie_booths.reserve_block or perms.cookie_booths.reserve_block_admin %}
+                                    <input type="button" id="ReserveBooth" value="Reserve Booth"
+                                           onclick="ReserveBooth({{ block.booth_block_information.id }},
+                                                '{{ block.booth_block_information.booth_day.booth.booth_requires_masks }}')">
+                                {% endif %}
 
-                        {% if block.booth_block_information.booth_block_reserved is False %}
-                            {% if perms.cookie_booths.reserve_block or perms.cookie_booths.reserve_block_admin %}
-                                <input type="button" id="ReserveBooth" value="Reserve Booth"
-                                       onclick="ReserveBooth({{ block.booth_block_information.id }},
-                                            '{{ block.booth_block_information.booth_day.booth.booth_requires_masks }}')">
+                            {% else %}
+                                {% if perms.cookie_booths.cancel_block_admin %}
+                                    Reserved by {{ block.booth_block_information.booth_block_current_troop_owner }}
+                                    <p></p>
+                                    <input type="button" id="CancelBooth" value="Cancel Booth"
+                                            onclick="CancelBooth({{ block.booth_block_information.id }})">
+                                {% elif  block.booth_owned_by_current_user is True %}
+                                    <input type="button" id="CancelBooth" value="Cancel Booth"
+                                            onclick="CancelBooth({{ block.booth_block_information.id }})">
+                                {% else %}
+                                    Reserved by {{ block.booth_block_information.booth_block_current_troop_owner }}
+                                {% endif %}
                             {% endif %}
 
-                        {% else %}
-                            {% if perms.cookie_booths.cancel_block_admin %}
-                                Reserved by {{ block.booth_block_information.booth_block_current_troop_owner }}
-                                <p></p>
-                                <input type="button" id="CancelBooth" value="Cancel Booth"
-                                        onclick="CancelBooth({{ block.booth_block_information.id }})">
-                            {% elif  block.booth_owned_by_current_user is True %}
-                                <input type="button" id="CancelBooth" value="Cancel Booth"
-                                        onclick="CancelBooth({{ block.booth_block_information.id }})">
+                        {% elif reserve_or_enable_booths == "enable" %}
+                            {% if block.booth_block_information.booth_block_enabled %}
+                                <input type="button" id="DisableBooth" value="Disable Booth"
+                                            onclick="DisableBooth({{ block.booth_block_information.id }})">
                             {% else %}
-                                Reserved by {{ block.booth_block_information.booth_block_current_troop_owner }}
+                                <input type="button" id="EnableBooth" value="Enable Booth"
+                                            onclick="EnableBooth({{ block.booth_block_information.id }})">
                             {% endif %}
                         {% endif %}
-
-
                     </td>
                 </tr>
             {% endfor %}
@@ -151,6 +159,36 @@
                 });
             }
 
+        }
+
+        function EnableBooth(booth_id) {
+            $.ajax({
+                    url: location.origin + "/booths/blocks/enable_blocks/" + booth_id,
+                    type: 'POST',
+                    data: {
+                        csrfmiddlewaretoken: '{{ csrf_token }}',
+                    },
+                    success: function (is_success){
+                        if (is_success === 'True') {
+                            window.location.reload()
+                        }
+                    }
+            });
+        }
+
+                function DisableBooth(booth_id) {
+            $.ajax({
+                    url: location.origin + "/booths/blocks/disable_blocks/" + booth_id,
+                    type: 'POST',
+                    data: {
+                        csrfmiddlewaretoken: '{{ csrf_token }}',
+                    },
+                    success: function (is_success){
+                        if (is_success === 'True') {
+                            window.location.reload()
+                        }
+                    }
+            });
         }
     </script>
 

--- a/cookie_website/cookie_booths/templates/cookie_booths/enable_blocks.html
+++ b/cookie_website/cookie_booths/templates/cookie_booths/enable_blocks.html
@@ -1,0 +1,87 @@
+{% extends "cookie_booths/base.html" %}
+{% load bootstrap4 %}
+
+
+{% block page_header %}
+    <h2>{{ page_title }}</h2>
+{% endblock page_header %}
+
+
+{% block content %}
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css">
+
+    <table id="booth_blocks" class="table table-striped table-bordered">
+        <thead>
+            <tr>
+                <th>Location</th>
+                <th>Date</th>
+                <th>Manage</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for day in booth_days %}
+                <tr>
+                    <td>{{ day.booth.booth_location }}</td>
+                    <td>{{ day.booth_day_date }}</td>
+                    <td>
+                        {% if day.booth_day_enabled %}
+                            <input type="button" id="DisableBooth" value="Disable Day"
+                                        onclick="DisableBooth({{ day.id }})">
+                        {% else %}
+                            <input type="button" id="EnableBooth" value="Enable Day"
+                                        onclick="EnableBooth({{ day.id }})">
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+    <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
+
+    <script type="text/javascript">
+    $(document).ready(function() {
+        $('#booth_blocks').DataTable( {
+    	    "paging":   false,
+        } );
+    } );
+    </script>
+
+    <script>
+        function EnableBooth(booth_id) {
+            $.ajax({
+
+                    url: location.origin + "/booths/blocks/enable_booth_days/enable",
+                    type: 'POST',
+                    data: {
+                        csrfmiddlewaretoken: '{{ csrf_token }}',
+                        booth_id: booth_id
+                    },
+                    success: function (){
+                        {
+                            window.location.reload()
+                        }
+                    }
+            });
+        }
+
+        function DisableBooth(booth_id) {
+            $.ajax({
+                    url: location.origin + "/booths/blocks/enable_booth_days/disable",
+                    type: 'POST',
+                    data: {
+                        csrfmiddlewaretoken: '{{ csrf_token }}',
+                        booth_id: booth_id
+                    },
+                    success: function (){
+                        {
+                            window.location.reload()
+                        }
+                    }
+            });
+        }
+    </script>
+
+
+{% endblock content %}

--- a/cookie_website/cookie_booths/urls.py
+++ b/cookie_website/cookie_booths/urls.py
@@ -24,4 +24,18 @@ urlpatterns = [
     path('booths/blocks/reservations/<int:block_id>', views.reserve_block, name='block_reservation'),
     # Cancel Booth Reservation
     path('booths/blocks/reservations/cancel/<int:block_id>', views.cancel_block, name='block_cancellation'),
+    # User Enable Booth by Block
+    path('booths/blocks/enable_blocks', views.enable_location_by_block, name='enable_location_by_block'),
+    # AJAX Enable Booth by Block
+    path('booths/blocks/enable_blocks/<int:block_id>', views.ajax_enable_location_by_block,
+         name='ajax_enable_location_by_block'),
+    # AJAX Disable Booth by Block
+    path('booths/blocks/disable_blocks/<int:block_id>', views.ajax_disable_location_by_block,
+         name='ajax_disable_location_by_block'),
+    # User Enable Booth Day
+    path('booths/blocks/enable_booth_days', views.enable_or_disable_day, name="enable_day"),
+    # AJAX Enable Booth by Day
+    path('booths/blocks/enable_booth_days/enable', views.enable_location_by_day, name="ajax_enable_day"),
+    # AJAX Disable Booth by Day
+    path('booths/blocks/enable_booth_days/disable', views.disable_location_by_day, name="ajax_disable_day"),
 ]


### PR DESCRIPTION
Updates:
+ Updated base.html with "Enable Booth by Block"
+ Updated booth_blocks.html with Enable/Disable capability
+ Updated models.py to have Enable/Disable in BoothBlocks
+ Added urls for enable booth by block, enable block and disable block using ajax
+ Likewise added items in views.py

Testing:
+ Manual Testing with admin, SUCM and TCC accounts.