### PR TITLE
[Feature] Enforce Ticket Booth System

### DIFF
--- a/cookie_booths/models.py
+++ b/cookie_booths/models.py
@@ -89,7 +89,7 @@ class BoothLocation(models.Model):
                     self.update_golden_day(date, hours.tuesday_golden_ticket)
                 elif date.weekday() == 2:  # Wednesday
                     self.add_or_update_day(date,
-                                           datetime.combine(date, hours.wendesday_open_time, tzinfo=utc),
+                                           datetime.combine(date, hours.wednesday_open_time, tzinfo=utc),
                                            datetime.combine(date, hours.wednesday_close_time, tzinfo=utc))
                     self.update_golden_day(date, hours.wednesday_golden_ticket)
                 elif date.weekday() == 3:  # Thursday

--- a/cookie_booths/tests.py
+++ b/cookie_booths/tests.py
@@ -4,8 +4,6 @@ from django.utils.timezone import make_aware
 from .models import BoothHours, BoothLocation, BoothDay, BoothBlock
 
 import datetime
-from datetime import timezone
-import pytz
 
 
 class BoothBlockTestCase(TestCase):

--- a/users/tests.py
+++ b/users/tests.py
@@ -58,15 +58,15 @@ class TroopTestCase(TestCase):
 
         # Now confirm the adds have been reflected in our counts that week
         self.assertTrue(
-            normal_troop.get_num_tickets_remaining(datetime.date(2021, 10, 18), datetime.date(2021, 10, 24)) == (4,0))
+            normal_troop.get_num_tickets_remaining(datetime.date(2021, 10, 22)) == (4, 0))
         self.assertTrue(
-            super_troop.get_num_tickets_remaining(datetime.date(2021, 10, 18), datetime.date(2021, 10, 24)) == (8,0))
+            super_troop.get_num_tickets_remaining(datetime.date(2021, 10, 22)) == (8, 0))
 
         # Make sure the counts are still ok for a different week
         self.assertTrue(
-            normal_troop.get_num_tickets_remaining(datetime.date(2021, 10, 25), datetime.date(2021, 10, 31)) == (5,1))
+            normal_troop.get_num_tickets_remaining(datetime.date(2021, 10, 28)) == (5, 1))
         self.assertTrue(
-            super_troop.get_num_tickets_remaining(datetime.date(2021, 10, 25), datetime.date(2021, 10, 31)) == (10,2))
+            super_troop.get_num_tickets_remaining(datetime.date(2021, 10, 28)) == (10, 2))
 
         # Now let's create a day sometime in that next week, at a normal location, same hours
         normal_location = BoothLocation.objects.create()
@@ -85,13 +85,12 @@ class TroopTestCase(TestCase):
 
         # Double check that the counts for the original week have not changed
         self.assertTrue(
-            normal_troop.get_num_tickets_remaining(datetime.date(2021, 10, 18), datetime.date(2021, 10, 24)) == (4, 0))
+            normal_troop.get_num_tickets_remaining(datetime.date(2021, 10, 22)) == (4, 0))
         self.assertTrue(
-            super_troop.get_num_tickets_remaining(datetime.date(2021, 10, 18), datetime.date(2021, 10, 24)) == (8, 0))
+            super_troop.get_num_tickets_remaining(datetime.date(2021, 10, 22)) == (8, 0))
 
         # And then make sure the counts for the new week have
         self.assertTrue(
-            normal_troop.get_num_tickets_remaining(datetime.date(2021, 10, 25), datetime.date(2021, 10, 31)) == (0, 1))
+            normal_troop.get_num_tickets_remaining(datetime.date(2021, 10, 28)) == (0, 1))
         self.assertTrue(
-            super_troop.get_num_tickets_remaining(datetime.date(2021, 10, 25), datetime.date(2021, 10, 31)) == (10, 2))
-
+            super_troop.get_num_tickets_remaining(datetime.date(2021, 10, 28)) == (10, 2))


### PR DESCRIPTION
When reserving a booth, we now check to see if tickets remain. If they do, allow user to reserve a booth. If they do not, do not allow user to reserve a booth.

Changes:
+ Changed way to check for date range so we only need the booth day in order to determine the week it belongs
+ Updated testbenches to reflect the above change
+ [FIX] Corrected typo in boothlocation model for Wednesdays
+ Removed superfluous imports from cookie_booths tests.py
+ Added ticket enforcement code to views.py in the booth reservation code

Testing:
+ Manual Testing (Passed)
+ Automated Testing (Passed)