### PR TITLE
[Update] Changed Troop Form to better reflect needs

### DIFF
--- a/users/forms.py
+++ b/users/forms.py
@@ -9,18 +9,14 @@ class TroopForm(forms.ModelForm):
     class Meta:
         model = Troop
         fields = ['troop_number',
-                  'troop_name',
                   'troop_cookie_coordinator',
                   'troop_level',
                   'super_troop']
 
         labels = {'troop_number': _('Troop Number'),
-                  'troop_name': _('Troop Nickname'),
-                  'troop_cookie_coordinator': _('Troop Cookie Coordinator E-mail Address'),
+                  'troop_cookie_coordinator': _('Troop Cookie Coordinator Username'),
                   'troop_level': _('Troop Level'),
                   'super_troop': _('Super Troop')}
-
-        help_texts = {'booth_enabled': _('Enabled means booth blocks are able to be reserved.')}
 
     def clean(self):
         # We want to make absolutely sure that we are not duplicating a troop. We should be able to find this uniquely

--- a/users/templates/troops/troops.html
+++ b/users/templates/troops/troops.html
@@ -11,7 +11,6 @@
 	<thead>
     	<tr>
         	<th>Troop ID</th>
-			<th>Troop Nickname</th>
 			<th>Troop Coordinator</th>
             {% if perms.users.troop_updates or perms.users.troop_deletion %}
                 <th>Actions</th>
@@ -22,7 +21,6 @@
 		{% for troop in troops %}
 			<tr>
 				<td>{{ troop.troop_number }}</td>
-				<td>{{ troop.troop_name }}</td>
                 <td>{{ troop.troop_cookie_coordinator }}</td>
 				<td>
                     {% if perms.users.troop_updates %}


### PR DESCRIPTION
Updates:
+ Troop form changed from using email address to username which is what it is actually asking for
+ Removed anything about Troop Nickname, as it isn't useful for the users

Testing:
+ Manual Testing passes