### PR TITLE
Fixed two minor bugs:

### DIFF
--- a/cookie_booths/models.py
+++ b/cookie_booths/models.py
@@ -332,14 +332,12 @@ class BoothDay(models.Model):
 
     def enable_freeforall(self):
         # If we're already enabled, nothing to do
-        if self.booth_day_freeforall_enabled and self.booth_day_enabled:
+        if self.booth_day_freeforall_enabled:
             return
 
         self.booth_day_freeforall_enabled = True
-        self.booth_day_enabled = True
 
         for block in BoothBlock.objects.filter(booth_day__id=self.id):
-            block.booth_block_enabled = True
             block.booth_block_freeforall_enabled = True
             block.save()
 
@@ -347,14 +345,12 @@ class BoothDay(models.Model):
 
     def disable_freeforall(self):
         # If we're already disabled, nothing to do
-        if not self.booth_day_freeforall_enabled and not self.booth_day_enabled:
+        if not self.booth_day_freeforall_enabled:
             return
 
         self.booth_day_freeforall_enabled = False
-        self.booth_day_enabled = False
 
         for block in BoothBlock.objects.filter(booth_day__id=self.id):
-            block.booth_block_enabled = False
             block.booth_block_freeforall_enabled = False
             block.save()
 

--- a/cookie_booths/views.py
+++ b/cookie_booths/views.py
@@ -431,7 +431,8 @@ def reserve_block(request, block_id):
         if booth_restrictions_start == 0:
             level_in_range = True
         else:
-            level_in_range = troop_trying_to_reserve_level in range(booth_restrictions_start, booth_restrictions_end)
+            level_in_range = troop_trying_to_reserve_level in \
+                             range(booth_restrictions_start, booth_restrictions_end + 1)
 
         if level_in_range:
             if block_to_reserve.reserve_block(troop_id=troop_trying_to_reserve):


### PR DESCRIPTION
1) Ambassador Troops cannot reserve a troop range booth -- Needed to add +1 to the range to make sure Ambassadors were included

2) When enabling FFA we should not also change whether the booth is enabled. I think the right thing to do is to skip disabled booths when doing FFA, but I will implement that for the second version of the website.