### PR TITLE
small fix to clean method in cookie_booth form

### DIFF
--- a/cookie_booths/forms.py
+++ b/cookie_booths/forms.py
@@ -170,6 +170,8 @@ class BoothHoursForm(forms.ModelForm):
         return data
     
     def clean(self):
+        super().clean()
+        
         # Make sure we have valid times - both populated is needed if the checkbox is checked
         for day in DAYS_OF_WEEK:
             self.__check_times_set_correctly(day_of_week=day)


### PR DESCRIPTION
From Django documentation: 

> The call to super().clean() in the example code ensures that any validation logic in parent classes is maintained. If your form inherits another that doesn’t return a cleaned_data dictionary in its clean() method (doing so is optional), then don’t assign cleaned_data to the result of the super() call and use self.cleaned_data instead: