### PR TITLE
Updating daisy troop views

### DIFF
--- a/cookie_booths/tests/test_booth_block_html.py
+++ b/cookie_booths/tests/test_booth_block_html.py
@@ -93,6 +93,11 @@ class BoothBlockHtmlTestCase(TestCase):
             troop_size=cls.DAISY_TROOP_DETAILS["troop_size"]
         )
 
+        cls.cookie_captain = get_user_model().objects.create_user(
+            email="cookies@monster.com",
+            password="cisforcookie",
+        )
+
         cls.location = BoothLocation.objects.create(
             booth_location=cls.BOOTH_DETAILS["booth_location"]
         )
@@ -391,7 +396,7 @@ class BoothBlockHtmlTestCase(TestCase):
         self.block.booth_block_held_for_cookie_captains = True
         self.block.save()
         self.block.reserve_block(
-            self.diff_troop.troop_number, self.diff_troop.troop_number
+            0, self.cookie_captain.id
         )
 
         self.client.login(
@@ -417,9 +422,8 @@ class BoothBlockHtmlTestCase(TestCase):
         self.block.booth_block_held_for_cookie_captains = True
         self.block.save()
         self.block.reserve_block(
-            self.diff_troop.troop_number, self.diff_troop.troop_number
+            0, self.cookie_captain.id
         )
-
         # Flag that same booth as owned by this daisy troop
         self.block.reserve_daisy_block(self.daisy_troop.troop_number)
 

--- a/cookie_booths/views.py
+++ b/cookie_booths/views.py
@@ -268,7 +268,7 @@ def booth_blocks(request):
     # 2a. If the active user belongs to a Daisy Troop, they should ONLY be able to see booths that 
     # are reserved by Cookie Captains.
     if is_daisy_troop:
-        booth_blocks_ = booth_blocks_.exclude(booth_block_current_cookie_captain_owner=NO_COOKIE_CAPTAIN_ID)
+        booth_blocks_ = booth_blocks_.filter(Q(booth_block_current_troop_owner=0) & Q(booth_block_reserved=True))
     # 2b. If the user is not a Cookie Captain, they should not be able to see booths held for CCs
     elif not is_cookie_captain:
         booth_blocks_ = booth_blocks_.exclude(booth_block_held_for_cookie_captains=True)


### PR DESCRIPTION
## Justification
Daisy troop reservations are not properly functioning because the filter is broken. Originally when we wrote the site, the user id was recorded as the cookie_captain_id. This means if I filter based on cookie_captain_id = 0, it will NOT filter out anything I reserved during the draft. So I'm updating the filter to look for anything reserved by troop 0 AND has been actually reserved

## Testing
Updated the automated testing to reflect the correct behavior. Passing.